### PR TITLE
Add missing dependencies to bats.toml

### DIFF
--- a/bats.toml
+++ b/bats.toml
@@ -2,3 +2,7 @@
 name = "str"
 kind = "lib"
 unsafe = false
+
+[dependencies]
+"arith" = ""
+"array" = ""


### PR DESCRIPTION
Every #use now has a matching [dependencies] entry.